### PR TITLE
feat: add RSS and Atom feeds

### DIFF
--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -20,6 +20,8 @@ jobs:
 
     - name: Install pipenv
       uses: dschep/install-pipenv-action@v1
+      with:
+        version: 2018.11.26
 
     - name: Install invoke
       run: pip install invoke

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -20,6 +20,8 @@ jobs:
 
     - name: Install pipenv
       uses: dschep/install-pipenv-action@v1
+      with:
+        version: 2018.11.26
 
     - name: Install invoke
       run: pip install invoke

--- a/Pipfile
+++ b/Pipfile
@@ -36,6 +36,7 @@ flask-cors = "*"
 jsonpath-ng = "*"
 pika = "*"
 fdk-rdf-parser = "*"
+feedgen = "*"
 
 [requires]
 python_version = "3.8"

--- a/src/endpoints.py
+++ b/src/endpoints.py
@@ -2,10 +2,13 @@ import json
 
 from flask_restful import Resource, abort
 from flask import request, Response
+
 from .search import client
 from .ingest import fetch_all_content, IndicesKey, fetch_data_sets, fetch_information_models, \
     fetch_data_services, fetch_concepts
 from .search.responses import SearchResponse, IndicesInfoResponse, SuggestionResponse
+
+from .service.feed import create_feed, FeedType
 
 
 class Search(Resource):
@@ -56,6 +59,17 @@ class SearchInformationModels(Resource):
 
 
 class SearchDataSet(Resource):
+    def get(self) -> Response:
+        mimetype = request.accept_mimetypes.best
+
+        if mimetype == "application/rss+xml":
+            return Response(response=create_feed(FeedType.RSS), mimetype=mimetype)
+
+        if mimetype == "application/atom+xml":
+            return Response(response=create_feed(FeedType.ATOM), mimetype=mimetype)
+
+        return abort(http_status_code=415, description="Unsupported media type")
+
     def post(self):
         page = 0
         if len(request.data) == 0:

--- a/src/service/feed.py
+++ b/src/service/feed.py
@@ -1,0 +1,67 @@
+from enum import Enum
+from typing import Iterable, Dict
+from feedgen.feed import FeedGenerator
+from flask import request
+
+from src.search import client
+from src.ingest import IndicesKey
+
+
+class FeedType(Enum):
+    RSS = "rss"
+    ATOM = "atom"
+
+
+def create_feed(feed_type: FeedType) -> str:
+    feed_generator = FeedGenerator()
+
+    feed_generator.id(request.url)
+    feed_generator.title("Felles datakatalog - Datasett")
+    feed_generator.description("En samling av datasett publisert i Felles datakataog")
+    feed_generator.link(href=request.url)
+
+    datasets = get_datasets_for_feed()
+
+    for dataset in datasets:
+        feed_entry = feed_generator.add_entry()
+
+        feed_entry.id(f"{request.url}/{dataset['id']}")
+        feed_entry.title(translate(dataset["title"]))
+        feed_entry.description(translate(dataset["description"]))
+        feed_entry.link(href=f"{request.url}/{dataset['id']}")
+        feed_entry.author(name=translate(dataset["publisher"]["prefLabel"] or dataset["publisher"]["name"]))
+        feed_entry.published(dataset["harvest"]["firstHarvested"])
+
+    if feed_type == FeedType.RSS:
+        return feed_generator.rss_str(pretty=True)
+    elif feed_type == FeedType.ATOM:
+        return feed_generator.atom_str(pretty=True)
+    else:
+        return ""
+
+
+def get_datasets_for_feed() -> Iterable[Dict]:
+    results = client.search_in_index(
+        index=IndicesKey.DATA_SETS,
+        request={
+            "filters": [
+                {
+                    "last_x_days": 1
+                }
+            ],
+            "sorting": {
+                "field": "harvest.firstHarvested",
+                "direction": "desc"
+            },
+            "size": 1000
+        }
+    )
+
+    if results["hits"] and results["hits"]["hits"]:
+        return map(lambda hit: hit["_source"], results["hits"]["hits"])
+
+    return []
+
+
+def translate(translatable: Dict[str, str]) -> str:
+    return translatable["nb"] or translatable["no"] or translatable["nn"] or translatable["en"]


### PR DESCRIPTION
@valosnah 
Tidligere var RSS og Atom eksponert under /datasets.rss og /datasets.atom. Nå er de tilgjengelig under GET /datasets med tilsvarende MIME-type. Det kan hende du må lage noen rewrites i nginx-konfig.